### PR TITLE
fix: WAL mode, curl dependency, gitignore improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,14 @@
 .env
 .venv
+venv311/
 __pycache__/
 *.py[cod]
 *$py.class
 .DS_Store
 data/*.db
 *.db
-__pycache__/
+*.db-shm
+*.db-wal
+StudentPicsDataset.xlsx
+~$*.xlsx
+*.diff

--- a/python-api/main.py
+++ b/python-api/main.py
@@ -2,10 +2,16 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from routers import emotion, attendance, session, gemini, notes, exam, roster, upload, auth
 from database import engine
+from sqlalchemy import text
 import models
 
 # Create database tables
 models.Base.metadata.create_all(bind=engine)
+
+# Enable WAL mode for concurrent reads (vision pipeline thread + API requests)
+with engine.connect() as conn:
+    conn.execute(text("PRAGMA journal_mode=WAL"))
+    conn.commit()
 
 app = FastAPI(title="AAST LMS API")
 

--- a/shiny-app/global.R
+++ b/shiny-app/global.R
@@ -15,6 +15,7 @@ library(ggplot2)
 library(dplyr)
 library(lubridate)
 library(httr2)
+library(curl)             # curl::form_file() for multipart roster/material uploads
 library(openxlsx)
 library(rmarkdown)
 library(bslib)


### PR DESCRIPTION
## Summary

Cherry-picked critical fixes from PRs #253 and #251, which could not be merged directly due to conflicts with Phase 3 already on `dev`.

- **WAL mode pragma** (`python-api/main.py`) — enables concurrent SQLite access between the vision pipeline thread and API requests; without this, DB locking errors occur under load
- **`library(curl)`** (`shiny-app/global.R`) — `curl::form_file()` is used by roster and material uploads in `lecturer_server.R` but the dependency was never declared; app would crash on a fresh install
- **`.gitignore` cleanup** — adds `*.db-shm`, `*.db-wal`, `StudentPicsDataset.xlsx`, `~$*.xlsx`, `*.diff`, `venv311/` to prevent binary/sensitive files from being committed

## Test plan
- [ ] `uvicorn main:app` starts without error; `/health` returns 200
- [ ] `sqlite3 data/classroom_emotions.db "PRAGMA journal_mode;"` returns `wal`
- [ ] R `library(curl)` loads without error after `install.packages("curl")`
- [ ] Roster XLSX upload succeeds from Shiny lecturer panel

Closes #253
Closes #251